### PR TITLE
Search stories in pull request description and comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ This danger plugin does exactly that :)
 
 ## How?
 
-The plugin will parse branch name and commit messages and find the pattern
-of `chXXXX` where `XXXX` is the story id to Clubhouse. Then, it will
-link to all the stories as a separated message in the format of
-`https://app.clubhouse.io/#{organization}/story/#{id}` for each story.
+This plugin will search for the pattern `chXXXX`, where `XXXX` is the story id 
+to Clubhouse, and links all story ids as a separated message in the format of 
+`https://app.clubhouse.io/#{organization}/story/#{id}`.
+
+It searches for the patterns in:
+
+- branch name
+- commit messages
+- pull request comments
+- pull request description
 
 ## Example
 
@@ -37,9 +43,17 @@ gem 'danger-clubhouse'
 
 Set the orgazination name for Clubhouse.
 
+```ruby
+clubhouse.organization = 'organization'
+```
+
 ### clubhouse.link_stories!
 
-Find stories in the format of chXXX from commits and branch name and
+Find the story ids and add the story links using the _Danger_ `markdown` methods.
+
+```ruby
+clubhouse.link_stories!
+```
 
 ## Thanks
 

--- a/danger-clubhouse.gemspec
+++ b/danger-clubhouse.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rubocop', '~> 0.41'
   spec.add_development_dependency 'yard', '~> 0.8'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
-  spec.add_development_dependency 'listen', '3.0.7'
+  spec.add_development_dependency 'listen', '~> 3.1'
   spec.add_development_dependency 'pry', '~> 0.10'
 end

--- a/lib/clubhouse/gem_version.rb
+++ b/lib/clubhouse/gem_version.rb
@@ -1,3 +1,3 @@
 module Clubhouse
-  VERSION = '0.0.2'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/clubhouse/plugin.rb
+++ b/lib/clubhouse/plugin.rb
@@ -31,50 +31,64 @@ module Danger
     # @return   [String]
     attr_accessor :organization
 
-    # Check the branch and commit messages to find clubhouse stories to link to.
+    # Check the branch, commit messages, comments and description to find clubhouse stories to link to.
     #
     # @return [void]
-    def link_stories!
-      clubhouse_story_ids = []
+    def link_stories!      
+      story_ids = find_all_story_ids
+      return if story_ids.empty?
 
-      # Check for the branch
-      if (story_id = find_story_id(github.branch_for_head))
-        clubhouse_story_ids << story_id
-      end
-
-      # Check all the commit messages
-      messages.each do |message|
-        if (story_id = find_story_id(message))
-          clubhouse_story_ids << story_id
-        end
-      end
-
-      post!(clubhouse_story_ids) unless clubhouse_story_ids.empty?
+      message = "### Clubhouse Stories\n\n"
+      story_ids.each do |id|
+        message << "* [#{story_link(id)}](#{story_link(id)}) \n"
+      end      
+      markdown message
     end
-
-    # Find clubhouse story id in the body
+    
+    # Find clubhouse story ids in the text.
+    #
+    # @return [Array<String>]
+    def find_story_ids(text)
+      text.scan(/ch(\d+)/).flatten
+    end
+    
+    # Find clubhouse story id in the text.
     #
     # @return [String, nil]
-    def find_story_id(body)
-      if (match = body.match(/ch(\d+)/))
-        return match[1]
-      end
-
-      nil
+    def find_story_id(text)
+      find_story_ids(text).first
     end
 
     private
 
-    def post!(story_ids)
-      message = "### Clubhouse Stories\n\n"
-      story_ids.each do |id|
-        message << "* [https://app.clubhouse.io/#{organization}/story/#{id}](https://app.clubhouse.io/#{organization}/story/#{id}) \n"
-      end
-      markdown message
+    def find_story_ids_in_branch
+      find_story_ids(github.branch_for_head) if defined? @dangerfile.github
     end
 
-    def messages
-      git.commits.map(&:message)
+    def find_story_ids_in_commits
+      git.commits.map { |commit| find_story_ids(commit.message) }.flatten
+    end
+    
+    def find_story_ids_in_description
+      find_story_ids(github.pr_body) if defined? @dangerfile.github
+    end
+
+    def find_story_ids_in_comments
+      if defined? @dangerfile.github
+        github
+          .api
+          .issue_comments(github.pr_json.head.repo.id, github.pr_json.number)
+          .map { |comment| find_story_ids(comment.body) }
+          .flatten
+      end
+    end
+    
+    def find_all_story_ids
+      find_story_ids_in_branch + find_story_ids_in_commits + find_story_ids_in_description + find_story_ids_in_comments
+    end
+      
+    def story_link(id)
+      "https://app.clubhouse.io/#{organization}/story/#{id}"
     end
   end
 end

--- a/lib/clubhouse/plugin.rb
+++ b/lib/clubhouse/plugin.rb
@@ -1,21 +1,21 @@
-module Danger
-  # This is your plugin class. Any attributes or methods you expose here will
-  # be available from within your Dangerfile.
-  #
-  # To be published on the Danger plugins site, you will need to have
-  # the public interface documented. Danger uses [YARD](http://yardoc.org/)
-  # for generating documentation from your plugin source, and you can verify
-  # by running `danger plugins lint` or `bundle exec rake spec`.
-  #
-  # You should replace these comments with a public description of your library.
-  #
-  # @example Ensure people are well warned about merging on Mondays
-  #
-  #          my_plugin.warn_on_mondays
-  #
-  # @see  Teng Siong Ong/danger-clubhouse
-  # @tags monday, weekends, time, rattata
-  #
+# This is your plugin class. Any attributes or methods you expose here will
+# be available from within your Dangerfile.
+#
+# To be published on the Danger plugins site, you will need to have
+# the public interface documented. Danger uses [YARD](http://yardoc.org/)
+# for generating documentation from your plugin source, and you can verify
+# by running `danger plugins lint` or `bundle exec rake spec`.
+#
+# You should replace these comments with a public description of your library.
+#
+# @example Ensure people are well warned about merging on Mondays
+#
+#          my_plugin.warn_on_mondays
+#
+# @see  Teng Siong Ong/danger-clubhouse
+# @tags monday, weekends, time, rattata
+#
+module Danger  
   # This plugin will detect stories from clubhouse and link to them.
   #
   # @example Customize the clubhouse organization and check for stories to link to them.

--- a/spec/clubhouse_spec.rb
+++ b/spec/clubhouse_spec.rb
@@ -20,16 +20,27 @@ module Danger
       context 'link_stories!' do
         let(:branch) { 'new_branch' }
         let(:body) { 'new body' }
+        let(:description) { 'new description' }
+        let(:comment_body) { 'new comment body' }
+        let(:repo_id) { 'my-username/my-repo' }
+        let(:pull_request_number) { 1 }
 
         subject do
           clubhouse.link_stories!
         end
 
         before do
+          allow(clubhouse.github).to receive_message_chain(:pr_json, :head, :repo, :id).and_return(repo_id)
+          allow(clubhouse.github).to receive_message_chain(:pr_json, :number).and_return(pull_request_number)
+
           commit = double(:commit, message: body)
           allow(clubhouse.git).to receive(:commits).and_return([commit])
 
+          comment = double(:comment, body: comment_body)
+          allow(clubhouse.github).to receive_message_chain(:api, :issue_comments).and_return([comment])
+
           allow(clubhouse.github).to receive(:branch_for_head).and_return(branch)
+          allow(clubhouse.github).to receive(:pr_body).and_return(description)
         end
 
         context 'in commit' do
@@ -79,6 +90,54 @@ module Danger
             end
           end
         end
+        
+        context 'in description' do
+          context 'with story id' do
+            let(:description) { '[ch345]' }
+
+            it 'links the story' do
+              subject
+
+              expect(status_report[:markdowns].map(&:message)).to eq [
+                "### Clubhouse Stories\n\n* [https://app.clubhouse.io/organization/story/345](https://app.clubhouse.io/organization/story/345) \n"
+              ]
+            end
+          end
+
+          context 'without story id' do
+            let(:description) { 'Fixed the issue #166.' }
+
+            it 'links to no stories' do
+              subject
+
+              expect(status_report[:markdowns].map(&:message)).to eq []
+            end
+          end
+        end
+
+        context 'in comments' do
+          context 'with story id' do
+            let(:comment_body) { 'Also implements this story [ch345].' }
+
+            it 'links the story' do
+              subject
+
+              expect(status_report[:markdowns].map(&:message)).to eq [
+                "### Clubhouse Stories\n\n* [https://app.clubhouse.io/organization/story/345](https://app.clubhouse.io/organization/story/345) \n"
+              ]
+            end
+          end
+
+          context 'without story id' do
+            let(:comment_body) { 'Good job!' }
+
+            it 'links to no stories' do
+              subject
+
+              expect(status_report[:markdowns].map(&:message)).to eq []
+            end
+          end
+        end
       end
 
       context 'find_story_id' do
@@ -99,6 +158,28 @@ module Danger
 
           it 'returns nil' do
             expect(subject).to eq(nil)
+          end
+        end
+      end
+      
+      context 'find_story_ids' do
+        subject do
+          clubhouse.find_story_ids(body)
+        end
+
+        context 'with proper story id in body' do
+          let(:body) { 'This is cool [ch345], also [ch346]' }
+
+          it 'finds the story ids' do
+            expect(subject).to eq(['345', '346'])
+          end
+        end
+
+        context 'without story id in body' do
+          let(:body) { 'This is cool' }
+
+          it 'returns empty array' do
+            expect(subject).to eq([])
           end
         end
       end


### PR DESCRIPTION
We needed at @kimoby to link Clubhouse stories from pull request description and pull request comments.

This is backward compatible since I did not change the existing API.

## Changelog

- add `find_story_ids(text)`
- search for stories in pull request description
- search for stories in pull request comments

```ruby
# Find clubhouse story ids in the text.
#
# @return [Array<String>]
def find_story_ids(text)
  text.scan(/ch(\d+)/).flatten
end
```